### PR TITLE
Fixed method not defined error when a server error is returned for polymer generated elements

### DIFF
--- a/java/src/com/basiscomponents/bridge/proxygen/Javascript/Javascript.java
+++ b/java/src/com/basiscomponents/bridge/proxygen/Javascript/Javascript.java
@@ -168,7 +168,7 @@ public class Javascript extends AbstractGenerator{
                 writer.printf("%sthis.session.create(this.id,'%s');\n", getSpaces(4), pe.getClassname());
             } else {
                 writer.printf(
-                        "%sthis.create(this.id,'::%s%s%s::%s');\n",
+                        "%sthis.session.create(this.id,'::%s%s%s::%s');\n",
                         getSpaces(4),
                         classfileprefix,
                         pe.getClassname(),

--- a/java/src/com/basiscomponents/bridge/proxygen/Javascript/Polymer.java
+++ b/java/src/com/basiscomponents/bridge/proxygen/Javascript/Polymer.java
@@ -274,12 +274,30 @@ public class Polymer extends AbstractGenerator {
 
                 writer.printf("%spromise : function(){\n", getSpaces(4));
                 writer.printf(
-                        "%sreturn this.model.session.promise.apply(this.model.session,arguments);\n",
+                        "%sreturn this.model.session.promise.apply(this.model.session,arguments)"
+                                + ".finally(function(){\n",
                         getSpaces(6)
                 );
+                if (pe.getClassname().contains(".")) {
+                    writer.printf(
+                            "%sthis.session.create(this.model.id,'%s');\n",
+                            getSpaces(8),
+                            pe.getClassname()
+                    );
+                } else {
+                    writer.printf(
+                            "%sthis.session.create(this.model.id,'::%s%s%s::%s');\n",
+                            getSpaces(8),
+                            classfileprefix,
+                            pe.getClassname(),
+                            classfilesuffix,
+                            pe.getClassname()
+                    );
+                }
+                writer.printf("%s}.bind(this));\n", getSpaces(6));
                 writer.printf("%s},\n\n", getSpaces(4));
 
-                writer.printf("%sexec : function(){\n", getSpaces(4));
+                //writer.printf("%sexec : function(){\n", getSpaces(4));
                 writer.printf(
                         "%sreturn this.model.session.exec.apply(this.model.session,arguments);\n",
                         getSpaces(6)


### PR DESCRIPTION
The problem ;

```html
<tf-customerbackendbc id="customer" session="{{session}}"></tf-customerbackendbc>
```

```js
createAccount : function(){

    var customer = this.$.customer;

    customer.pushVar('username',this.username);
    customer.pushVar('password',this.password);
    customer.createAccount("username","password");

    customer.promise().then(
      function(response){
        this.log('Created Account');
      }.bind(this),

      function(error){
        this.errors.push('Unable to create account');
      }.bind(this)
    );
  },
```
* Request sent to server `createAccount`
* Error from server `Email is incorrect`
* Try again with different email results `Attempt to invoke method createAccount of  null object`

In this point session is corrupted , even if you enter valid information.

The PR attends to solve this problem 