### PR TITLE
Fix polymer generator to handle edge cases

### DIFF
--- a/java/src/com/basiscomponents/bridge/proxygen/Javascript/Javascript.java
+++ b/java/src/com/basiscomponents/bridge/proxygen/Javascript/Javascript.java
@@ -168,7 +168,7 @@ public class Javascript extends AbstractGenerator{
                 writer.printf("%sthis.session.create(this.id,'%s');\n", getSpaces(4), pe.getClassname());
             } else {
                 writer.printf(
-                        "%sthis.create(this.id,'::%s%s%s::%s');\n",
+                        "%sthis.session.create(this.id,'::%s%s%s::%s');\n",
                         getSpaces(4),
                         classfileprefix,
                         pe.getClassname(),


### PR DESCRIPTION
The polymer generator generates new method called `recomputeModel`  for every element 

# The problem : 


```html
<tf-customerbackendbc id="customer" session="{{session}}"></tf-customerbackendbc>
```

```js
createAccount : function(){

    var customer = this.$.customer;

    customer.pushVar('username',this.username);
    customer.pushVar('password',this.password);
    customer.createAccount("username","password");

    customer.promise().then(
      function(response){
        this.log('Created Account');
      }.bind(this),

      function(error){
          // do something 
      }.bind(this)
    );
  },
```
* Request sent to server `createAccount`
* Error from server `Email is incorrect`
* Try again with different email results `Attempt to invoke method createAccount of  null object`

In this point session is corrupted , even if you enter valid information.

The code must be updated to be written in the following way  : 

```js


    customer.promise('test label')
    .then(
      function(response){
        this.log('Created Account Successfully');
      }.bind(this),

      function(error){
        // do someting here
      }.bind(this)
    )
    .finally(function(){
      // we must recompute the model , it means [new TF.CustomerBackendBC(session)]
      customer.recomputeModel();
    }.bind(this));

```
